### PR TITLE
Fix print not logging nil values

### DIFF
--- a/Utils.lua
+++ b/Utils.lua
@@ -1,8 +1,8 @@
 -- Overrides print to call Package Log instead
 print = function(...)
 	local toprint = ""
-	for i, v in ipairs({...}) do
-		toprint = toprint .. tostring(v) .. "\t"
+	for i = 1, select("#", ...) do
+		toprint = toprint .. tostring(select(i, ...)) .. "\t"
 	end
 
 	return Package:Log(toprint)


### PR DESCRIPTION
Because `ipairs` by implementation stops when find a nil value, it has a bug when trying to print  `nil` variables