### PR TITLE
Optimize NanosUtils.Dump performance

### DIFF
--- a/NanosUtils.lua
+++ b/NanosUtils.lua
@@ -45,7 +45,7 @@ function NanosUtils.Dump(full_object)
 			table_insert(buffer, indentation == 1 and "\n{" or "{")
 
 			-- For each member of the table, recursively outputs it
-			for k, key in pairs(keys) do
+			for k, key in ipairs(keys) do
 				table_insert(buffer, "\n" .. string.rep(" ", indentation * 4) .. tostring(key) .. " = ")
 				DumpRecursive(object[key], indentation)
 				table_insert(buffer, ",")

--- a/NanosUtils.lua
+++ b/NanosUtils.lua
@@ -3,66 +3,66 @@
 NanosUtils = {}
 
 function NanosUtils.IsA(object, class)
-    return getmetatable(object) == class
+	return getmetatable(object) == class
 end
 
 function NanosUtils.Dump(full_object)
-    -- Table used to store already visited tables (avoid recursion)
-    local visited = {}
-    -- Table used to store the final output, which will be concatted in the end
-    local buffer = {}
-    -- Cache table.insert as local because it's faster
-    local table_insert = table.insert
+	-- Table used to store already visited tables (avoid recursion)
+	local visited = {}
+	-- Table used to store the final output, which will be concatted in the end
+	local buffer = {}
+	-- Cache table.insert as local because it's faster
+	local table_insert = table.insert
 
-    -- Internal recursive function
-    local function DumpRecursive(object, indentation)
-        local object_type = type(object)
+	-- Internal recursive function
+	local function DumpRecursive(object, indentation)
+		local object_type = type(object)
 
-        -- If it's a table and was not outputted yet
-        if (object_type == 'table' and not visited[object]) then
-            -- Marks as visited
-            visited[object] = true
+		-- If it's a table and was not outputted yet
+		if (object_type == 'table' and not visited[object]) then
+			-- Marks as visited
+			visited[object] = true
 
-            -- Stores all keys in another table, sorting it
-            local keys = {}
+			-- Stores all keys in another table, sorting it
+			local keys = {}
 
-            for key, v in pairs(object) do
-                table_insert(keys, key)
-            end
+			for key, v in pairs(object) do
+				table_insert(keys, key)
+			end
 
-            table.sort(keys, function(a, b)
-                if type(a) == "number" and type(b) == "number" then
-                    return a < b
-                else
-                    return tostring(a) < tostring(b)
-                end
-            end)
+			table.sort(keys, function(a, b)
+				if type(a) == "number" and type(b) == "number" then
+					return a < b
+				else
+					return tostring(a) < tostring(b)
+				end
+			end)
 
-            -- Increases one indentation, as we will start outputting table elements
-            indentation = indentation + 1
+			-- Increases one indentation, as we will start outputting table elements
+			indentation = indentation + 1
 
-            -- Main table displays '{' in a separated line, subsequent ones will be in the same line
-            table_insert(buffer, indentation == 1 and "\n{" or "{")
+			-- Main table displays '{' in a separated line, subsequent ones will be in the same line
+			table_insert(buffer, indentation == 1 and "\n{" or "{")
 
-            -- For each member of the table, recursively outputs it
-            for k, key in pairs(keys) do
-                table_insert(buffer, "\n" .. string.rep(" ", indentation * 4) .. tostring(key) .. " = ")
-                DumpRecursive(object[key], indentation)
-                table_insert(buffer, ",")
-            end
+			-- For each member of the table, recursively outputs it
+			for k, key in pairs(keys) do
+				table_insert(buffer, "\n" .. string.rep(" ", indentation * 4) .. tostring(key) .. " = ")
+				DumpRecursive(object[key], indentation)
+				table_insert(buffer, ",")
+			end
 
-            -- After outputted the whole table, backs one indentation
-            indentation = indentation - 1
+			-- After outputted the whole table, backs one indentation
+			indentation = indentation - 1
 
-            -- Adds the closing bracket
-            table_insert(buffer, "\n" .. string.rep(" ", indentation * 4) .. "}")
-        elseif (object_type == "string") then
-            table_insert(buffer, '"' .. tostring(object) .. '"')
-        else
-            table_insert(buffer, tostring(object))
-        end
-    end
+			-- Adds the closing bracket
+			table_insert(buffer, "\n" .. string.rep(" ", indentation * 4) .. "}")
+		elseif (object_type == "string") then
+			table_insert(buffer, '"' .. tostring(object) .. '"')
+		else
+			table_insert(buffer, tostring(object))
+		end
+	end
 
-    DumpRecursive(full_object, 0)
-    return table.concat(buffer)
+	DumpRecursive(full_object, 0)
+	return table.concat(buffer)
 end

--- a/NanosUtils.lua
+++ b/NanosUtils.lua
@@ -3,68 +3,66 @@
 NanosUtils = {}
 
 function NanosUtils.IsA(object, class)
-	return getmetatable(object) == class
+    return getmetatable(object) == class
 end
 
 function NanosUtils.Dump(full_object)
-	-- Table used to store already visited tables (avoid recursion)
-	local visited = {}
+    -- Table used to store already visited tables (avoid recursion)
+    local visited = {}
+    -- Table used to store the final output, which will be concatted in the end
+    local buffer = {}
+    -- Cache table.insert as local because it's faster
+    local table_insert = table.insert
 
-	-- Internal recursive function
-	local function DumpRecursive(object, indentation)
-		local object_type = type(object)
+    -- Internal recursive function
+    local function DumpRecursive(object, indentation)
+        local object_type = type(object)
 
-		-- If it's a table and was not outputted yet
-		if (object_type == 'table' and not visited[object]) then
-			-- Marks as visited
-			visited[object] = true
+        -- If it's a table and was not outputted yet
+        if (object_type == 'table' and not visited[object]) then
+            -- Marks as visited
+            visited[object] = true
 
-			-- Table used to store the final output, which will be concatted in the end
-			local output_table = {}
+            -- Stores all keys in another table, sorting it
+            local keys = {}
 
-			-- Stores all keys in another table, sorting it
-			local keys = {}
+            for key, v in pairs(object) do
+                table_insert(keys, key)
+            end
 
-			for key, v in pairs(object) do
-				table.insert(keys, key)
-			end
+            table.sort(keys, function(a, b)
+                if type(a) == "number" and type(b) == "number" then
+                    return a < b
+                else
+                    return tostring(a) < tostring(b)
+                end
+            end)
 
-			table.sort(keys, function(a, b)
-				if type(a) == "number" and type(b) == "number" then
-					return a < b
-				else
-					return tostring(a) < tostring(b)
-				end
-			end)
+            -- Increases one indentation, as we will start outputting table elements
+            indentation = indentation + 1
 
-			-- Increases one indentation, as we will start outputting table elements
-			indentation = indentation + 1
+            -- Main table displays '{' in a separated line, subsequent ones will be in the same line
+            table_insert(buffer, indentation == 1 and "\n{" or "{")
 
-			-- Main table displays '{' in a separated line, subsequent ones will be in the same line
-			table.insert(output_table, indentation == 1 and "\n{" or "{")
+            -- For each member of the table, recursively outputs it
+            for k, key in pairs(keys) do
+                table_insert(buffer, "\n" .. string.rep(" ", indentation * 4) .. tostring(key) .. " = ")
+                DumpRecursive(object[key], indentation)
+                table_insert(buffer, ",")
+            end
 
-			-- For each member of the table, recursively outputs it
-			for k, key in pairs(keys) do
-				table.insert(output_table, "\n" .. string.rep(" ", indentation * 4) .. tostring(key) .. " = " .. DumpRecursive(object[key], indentation) .. ",")
-			end
+            -- After outputted the whole table, backs one indentation
+            indentation = indentation - 1
 
-			-- After outputted the whole table, backs one indentation
-			indentation = indentation - 1
+            -- Adds the closing bracket
+            table_insert(buffer, "\n" .. string.rep(" ", indentation * 4) .. "}")
+        elseif (object_type == "string") then
+            table_insert(buffer, '"' .. tostring(object) .. '"')
+        else
+            table_insert(buffer, tostring(object))
+        end
+    end
 
-			-- Adds the closing bracket
-			table.insert(output_table, "\n" .. string.rep(" ", indentation * 4) .. "}")
-
-			-- After all, concats all elements into the output
-			return table.concat(output_table)
-		else
-			-- Outputs string with quotes
-			if (object_type == "string") then
-				return '"' .. tostring(object) .. '"'
-			else
-				return tostring(object)
-			end
-		end
-	end
-
-	return DumpRecursive(full_object, 0)
+    DumpRecursive(full_object, 0)
+    return table.concat(buffer)
 end


### PR DESCRIPTION
Benchmarking: https://lua.ceifa.tv/?paste=bejexuyeqa

- Since we already decreased the immutable string concatenations, lets buffer everything into a table and concat only when returning the final result.
- Always use ipairs over pairs to sequential tables
- Cache table.insert into a local variable because it's being heavy used and globals are slow

```
Actual Dump:
Benchmark results: 500 function calls | 47000.00 microseconds elapsed | 94.00 microseconds avg execution time.

This PR Dump:
Benchmark results: 500 function calls | 14000.00 microseconds elapsed | 28.00 microseconds avg execution time.
```