### PR TITLE
require fix

### DIFF
--- a/Client.lua
+++ b/Client.lua
@@ -1,4 +1,9 @@
 -- Adds 'require' as alias to 'Package.Require()'
-require = function(...)
-	return Package.Require(...)
+require = function(module_name, ...)
+    local calling_ENV = __GetCalling_ENV(3)
+    if calling_ENV then
+        return calling_ENV.Package.Require(module_name)
+    else
+        error("Cannot get calling _ENV for require")
+    end
 end

--- a/Server.lua
+++ b/Server.lua
@@ -1,7 +1,8 @@
 -- Adds 'require' to searchers
 table.insert(package.searchers, function(module_name)
-	local success, result = pcall(Package.Require, Package, module_name)
-	if (success) then
-		return function() return result end
-	end
+    local calling_ENV = __GetCalling_ENV(4)
+    if calling_ENV then
+        local result = calling_ENV.Package.Require(module_name)
+        return function() return result end
+    end
 end)

--- a/Shared.lua
+++ b/Shared.lua
@@ -14,3 +14,39 @@ print = function(...)
 	-- After all, concats the results
 	return Console.Log(table.concat(buffer))
 end
+
+function __GetPackageName(env)
+    if (env.Package and env.Package.GetName and env.Package.GetCompatibilityVersion) then
+        local compat = env.Package.GetCompatibilityVersion()
+        local compat_v_split = string.split(compat, ".")
+        if (compat == "" or not compat) then
+            return env.Package.GetPath()
+        elseif ((tonumber(compat_v_split[1]) == 1 and tonumber(compat_v_split[2]) >= 49) or tonumber(compat_v_split[1]) > 1) then
+            return env.Package.GetName()
+        else
+            return env.Package.GetPath()
+        end
+    end
+end
+
+function __GetCalling_ENV(level)
+    local info = debug.getinfo(level, "S")
+    if (info and info.source) then
+
+        local splited_source = string.split(info.source, "/")
+        if splited_source[1] then
+            local package_name = splited_source[1]
+
+            if (debug and debug.getregistry) then
+                local envs = debug.getregistry().environments
+                if envs then
+                    for k, v in pairs(envs) do
+                        if (__GetPackageName(k) == package_name) then
+                            return k
+                        end
+                    end
+                end
+            end
+        end
+    end
+end

--- a/string.lua
+++ b/string.lua
@@ -21,3 +21,10 @@ function string.FormatArgs(str, ...)
 
 	return str
 end
+
+function string.split(str, sep) -- basic string.split handling 1 character for sep.
+    local sep, fields = sep or ":", {}
+    local pattern = string.format("([^%s]+)", sep)
+    str:gsub(pattern, function(c) fields[#fields+1] = c end)
+    return fields
+end


### PR DESCRIPTION
Won't work for injected scripts (Package.Require(other_package_name/.../*.lua or Package.RequirePackage scripts) because you don't want my source convention for them.

Also adds a string.split(str, sep) function in the string library.
 